### PR TITLE
[STUDIO-1547] Update sample for Katalon Azure DevOps Extension

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-latest'
 
 steps:
 - task: katalonTask@1


### PR DESCRIPTION
Update For publishing Katalon Azure DevOps Extension 1.1.1

The katalonTask@1 is still available due to our major version is 1